### PR TITLE
fix bug: isOptional=false not true means cannot

### DIFF
--- a/docs/src/site/twiki/TypeSystem.twiki
+++ b/docs/src/site/twiki/TypeSystem.twiki
@@ -139,7 +139,7 @@ db:
     "isUnique":    false,
     "cardinality": "SINGLE"</verbatim>
 
-Note the “isOptional=true” constraint - a table entity cannot be created without a db reference.
+Note the “isOptional=false” constraint - a table entity cannot be created without a db reference.
 
 <verbatim>
 columns:


### PR DESCRIPTION
> Note the “isOptional=true” constraint - a table entity cannot be created without a db reference.
"true" should change to "false"